### PR TITLE
Merge back from master 

### DIFF
--- a/_docs/release-notes/index.html
+++ b/_docs/release-notes/index.html
@@ -16,7 +16,7 @@ is_article: false
       <hr/>
         <h2>BaseSpace</h2>
         <ul>
-           <li><a href="/release-notes/basespace/2016/4.0.0/" class="accordion-link">January 21, 2015 - 4.0.0 - Updates to BaseSpace Interface</a></li>
+           <li><a href="/release-notes/basespace/2016/4.0.0/" class="accordion-link">January 21, 2016 - 4.0.0 - Updates to BaseSpace Interface</a></li>
            <li><a href="/release-notes/basespace/2015/3.23.2/" class="accordion-link">December 11, 2015 - 3.23.2 - Bug Fix and Input Form Update</a></li>
            <li><a href="/release-notes/basespace/2015/3.23.1/" class="accordion-link">December 9, 2015 - 3.23.1 - FASTQ Generation Name Verification and IGV Fixes</a></li>
            <li><a href="/release-notes/basespace/2015/3.23.0/" class="accordion-link">December 1, 2015 - 3.23.0 - FASTQ Generation and Run UI Updates</a></li>


### PR DESCRIPTION
In-place bug fixes to get the video step captions appearing correctly.

For future reference, don't use backticks, use 4 spaces instead.