### PR TITLE
Fixed typo and added missing information

### DIFF
--- a/_docs/articles/descriptive/fastq-files.md
+++ b/_docs/articles/descriptive/fastq-files.md
@@ -78,7 +78,7 @@ The following table describes the elements:
 	<tr>
 		<td><code>&lt;flowcell ID&gt;</code></td>
 		<td>Characters allowed: a–z, A–Z, 0–9</td>
-		<td></td>
+		<td>Flowcell ID</td>
 	</tr>
 	<tr>
 		<td><code>&lt;lane&gt;</code></td>
@@ -93,12 +93,12 @@ The following table describes the elements:
 	<tr>
 		<td><code>&lt;x_pos&gt;</code></td>
 		<td>Numerical</td>
-		<td>Run number on instrument</td>
+		<td>X coordinate of cluster</td>
 	</tr>
 	<tr>
 		<td><code>&lt;y_pos&gt;</code></td>
 		<td>Numerical</td>
-		<td>X coordinate of cluster</td>
+		<td>Y coordinate of cluster</td>
 	</tr>
 	<tr>
 		<td><code>&lt;read&gt;</code></td>


### PR DESCRIPTION
The X and Y coordinate entries were incorrect, and I filled in the flow cell ID description. I'm not sure why the diff is highlighting the last paragraph as it's completely unchanged.