### PR TITLE
Fix formatting of `_` in file names

### DIFF
--- a/_docs/articles/descriptive/fastq-files.md
+++ b/_docs/articles/descriptive/fastq-files.md
@@ -21,7 +21,7 @@ BaseSpace Sequence Hub automatically generates FASTQ files in sample sheet-drive
 ###Naming
 
 FASTQ files are named with the sample name and the sample number, which is a numeric assignment based on the order that the sample is listed in the sample sheet. 
-Example: Data\Intensities\BaseCalls\samplename_S1_L001_R1_001.fastq.gz
+Example: `Data\Intensities\BaseCalls\samplename_S1_L001_R1_001.fastq.gz`
 
 - samplename—The sample name provided in the sample sheet. If a sample name is not provided, the file name includes the sample ID, which is a required field in the sample sheet and must be unique.
 - S1—The sample number based on the order that samples are listed in the sample sheet starting with 1. In this example, S1 indicates that this sample is the first sample listed in the sample sheet.


### PR DESCRIPTION
The `_` in the file name got interpreted as a markup character. Marking the full file name as a code fragment fixes this.

Before the fix, the file name was incorrectly rendered as:
![Screenshot 2020-02-13 at 15 20 58](https://user-images.githubusercontent.com/302566/74449965-442a8980-4e75-11ea-8950-7cad9e71eb49.png)
